### PR TITLE
fix: remove extra div in accordion

### DIFF
--- a/.changeset/itchy-fireants-melt.md
+++ b/.changeset/itchy-fireants-melt.md
@@ -1,0 +1,5 @@
+---
+"@govtechmy/myds-react": patch
+---
+
+Remove extra div in AccordionContent

--- a/packages/react/src/components/accordion.tsx
+++ b/packages/react/src/components/accordion.tsx
@@ -68,12 +68,13 @@ const AccordionContent = React.forwardRef<
       "text-txt-black-700 font-body text-body-sm relative overflow-hidden font-normal transition-all duration-300",
       "data-[state=open]:animate-slide-down data-[state=closed]:animate-slide-up",
       "data-[state=closed]:opacity-0 data-[state=open]:opacity-100",
+      "overflow-hidden pb-4 pr-9",
       className,
     )}
     {...props}
     ref={forwardedRef}
   >
-    <div className="overflow-hidden pb-4 pr-9">{children}</div>
+    {children}
   </AccordionBase.Content>
 ));
 


### PR DESCRIPTION
1. Remove extra div element in AccordionContent, and move the "overflow-hidden pb-4 pr-9" to the parent such that it can be overwritten