### PR TITLE
Fix/announce bar

### DIFF
--- a/.changeset/small-actors-whisper.md
+++ b/.changeset/small-actors-whisper.md
@@ -1,0 +1,7 @@
+---
+"@govtechmy/myds-storybook": patch
+"@govtechmy/myds-react": patch
+---
+
+1. Remove asChild props from AnnounceBarDescription
+2. Small refactor on AnnounceBatTag

--- a/apps/storybook/stories/announce-bar.stories.tsx
+++ b/apps/storybook/stories/announce-bar.stories.tsx
@@ -4,7 +4,6 @@ import { createStory } from "../utils";
 import {
   AnnounceBar,
   AnnounceBarDescription,
-  AnnounceBarProps,
   AnnounceBarTag,
 } from "@govtechmy/myds-react/announce-bar";
 import { Link } from "@govtechmy/myds-react/link";

--- a/apps/storybook/stories/announce-bar.stories.tsx
+++ b/apps/storybook/stories/announce-bar.stories.tsx
@@ -139,7 +139,7 @@ export const DarkPrimary: Story = {
     return (
       <AnnounceBar className={className}>
         <AnnounceBarTag variant="primary">Alpha</AnnounceBarTag>
-        <AnnounceBarDescription asChild>
+        <AnnounceBarDescription>
           <p>
             This is a new service. Help us improve it.{" "}
             <Link underline="always" primary href="#">
@@ -162,7 +162,7 @@ export const DarkSuccess: Story = {
     return (
       <AnnounceBar className={className}>
         <AnnounceBarTag variant="success">Public Beta</AnnounceBarTag>
-        <AnnounceBarDescription asChild>
+        <AnnounceBarDescription>
           <p>
             Welcome to Public Beta! Try out the service and share your feedback.{" "}
             <Link underline="always" primary href="#">

--- a/apps/storybook/stories/announce-bar.stories.tsx
+++ b/apps/storybook/stories/announce-bar.stories.tsx
@@ -22,11 +22,11 @@ import { Link } from "@govtechmy/myds-react/link";
  * import { AnnounceBar, AnnounceBarDescription, AnnounceBarProps, AnnounceBarTag } from "@govtechmy/myds-react/announce-bar";
  *
  * <AnnounceBar {...args}>
- *       <AnnounceBarTag variant="primary">
+ *       <AnnounceBarTag variant="primary" mode="pill">
  *         Alpha
  *       </AnnounceBarTag>
  *       <AnnounceBarDescription>
- *         <p>This is a new service. Help us improve it. <Link underline="always" primary * *href="#">Send us your feedback here.</Link></p>
+ *         <p>This is a new service. Help us improve it. <Link underline="always" primary href="#">Send us your feedback here.</Link></p>
  *       </AnnounceBarDescription>
  * </AnnounceBar>
  * ```
@@ -51,7 +51,9 @@ export const LightPrimary: Story = {
   render: () => {
     return (
       <AnnounceBar>
-        <AnnounceBarTag variant="primary">Alpha</AnnounceBarTag>
+        <AnnounceBarTag variant="primary" mode="pill">
+          Alpha
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>
             This is a new service. Help us improve it.{" "}
@@ -74,7 +76,9 @@ export const LightSuccess: Story = {
   render: () => {
     return (
       <AnnounceBar>
-        <AnnounceBarTag variant="success">Public Beta</AnnounceBarTag>
+        <AnnounceBarTag variant="success" mode="pill">
+          Public Beta
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>
             Welcome to Public Beta! Try out the service and share your feedback.{" "}
@@ -97,7 +101,9 @@ export const LightWarning: Story = {
   render: () => {
     return (
       <AnnounceBar>
-        <AnnounceBarTag variant="warning">Maintenance</AnnounceBarTag>
+        <AnnounceBarTag variant="warning" mode="pill">
+          Maintenance
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>
             This service is undergoing maintenance. Thank you for your patience.{" "}
@@ -120,7 +126,9 @@ export const LightDanger: Story = {
   render: () => {
     return (
       <AnnounceBar>
-        <AnnounceBarTag variant="danger">Retired</AnnounceBarTag>
+        <AnnounceBarTag variant="danger" mode="pill">
+          Retired
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>This service has been retired and is no longer available.</p>
         </AnnounceBarDescription>
@@ -137,7 +145,9 @@ export const DarkPrimary: Story = {
   render: ({ className }) => {
     return (
       <AnnounceBar className={className}>
-        <AnnounceBarTag variant="primary">Alpha</AnnounceBarTag>
+        <AnnounceBarTag variant="primary" mode="pill">
+          Alpha
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>
             This is a new service. Help us improve it.{" "}
@@ -160,7 +170,9 @@ export const DarkSuccess: Story = {
   render: ({ className }) => {
     return (
       <AnnounceBar className={className}>
-        <AnnounceBarTag variant="success">Public Beta</AnnounceBarTag>
+        <AnnounceBarTag variant="success" mode="pill">
+          Public Beta
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>
             Welcome to Public Beta! Try out the service and share your feedback.{" "}
@@ -182,7 +194,9 @@ export const DarkWarning: Story = {
   render: ({ className }) => {
     return (
       <AnnounceBar className={className}>
-        <AnnounceBarTag variant="warning">Maintenance</AnnounceBarTag>
+        <AnnounceBarTag variant="warning" mode="pill">
+          Maintenance
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>
             This service is undergoing maintenance. Thank you for your patience.{" "}
@@ -205,7 +219,9 @@ export const DarkDanger: Story = {
   render: ({ className }) => {
     return (
       <AnnounceBar className={className}>
-        <AnnounceBarTag variant="danger">Retired</AnnounceBarTag>
+        <AnnounceBarTag variant="danger" mode="pill">
+          Retired
+        </AnnounceBarTag>
         <AnnounceBarDescription>
           <p>This service has been retired and is no longer available.</p>
         </AnnounceBarDescription>

--- a/packages/react/src/components/announce-bar.tsx
+++ b/packages/react/src/components/announce-bar.tsx
@@ -29,39 +29,7 @@ const AnnounceBar: ForwardRefExoticComponent<ComponentProps<"div">> =
     );
   });
 
-const AnnounceBarTag: ForwardRefExoticComponent<
-  Omit<ComponentProps<typeof Tag>, "size" | "mode"> & { asChild?: boolean }
-> = forwardRef(
-  (
-    { variant = "primary", children, className, asChild = false, ...props },
-    ref,
-  ) => {
-    if (asChild) {
-      return (
-        <Slot
-          ref={ref}
-          {...props}
-          className={clx("flex-shrink-0 whitespace-nowrap", className)}
-        >
-          {children}
-        </Slot>
-      );
-    }
-
-    return (
-      <Tag
-        ref={ref}
-        {...props}
-        variant={variant}
-        size="medium"
-        mode="default"
-        className={clx("flex-shrink-0 whitespace-nowrap", className)}
-      >
-        {children}
-      </Tag>
-    );
-  },
-);
+const AnnounceBarTag: typeof Tag = Tag;
 
 const AnnounceBarDescription: ForwardRefExoticComponent<ComponentProps<"div">> =
   forwardRef(({ children, className, ...props }, ref) => {

--- a/packages/react/src/components/announce-bar.tsx
+++ b/packages/react/src/components/announce-bar.tsx
@@ -30,16 +30,26 @@ const AnnounceBar: ForwardRefExoticComponent<ComponentProps<"div">> =
   });
 
 const AnnounceBarTag: ForwardRefExoticComponent<
-  ComponentProps<typeof Tag> & { asChild?: boolean }
+  Omit<ComponentProps<typeof Tag>, "size" | "mode"> & { asChild?: boolean }
 > = forwardRef(
   (
     { variant = "primary", children, className, asChild = false, ...props },
     ref,
   ) => {
-    const Comp = asChild ? Slot : Tag;
+    if (asChild) {
+      return (
+        <Slot
+          ref={ref}
+          {...props}
+          className={clx("flex-shrink-0 whitespace-nowrap", className)}
+        >
+          {children}
+        </Slot>
+      );
+    }
 
     return (
-      <Comp
+      <Tag
         ref={ref}
         {...props}
         variant={variant}
@@ -48,7 +58,7 @@ const AnnounceBarTag: ForwardRefExoticComponent<
         className={clx("flex-shrink-0 whitespace-nowrap", className)}
       >
         {children}
-      </Comp>
+      </Tag>
     );
   },
 );

--- a/packages/react/src/components/tag.tsx
+++ b/packages/react/src/components/tag.tsx
@@ -1,9 +1,18 @@
-import React, { ComponentProps, forwardRef, FunctionComponent } from "react";
+import React, {
+  ComponentProps,
+  forwardRef,
+  ForwardRefExoticComponent,
+  FunctionComponent,
+  RefAttributes,
+} from "react";
 import { cva, VariantProps } from "class-variance-authority";
 import { clx } from "../utils";
 
 const tag_cva = cva(
-  ["inline-flex gap-[5px] font-medium font-body justify-center items-center"],
+  [
+    "inline-flex gap-[5px] font-medium font-body justify-center items-center",
+    "flex-shrink-0 whitespace-nowrap",
+  ],
   {
     variants: {
       variant: {
@@ -55,30 +64,38 @@ const dot_cva = cva(["inline-block rounded-full text-inherit bg-current"], {
  */
 interface TagProps extends ComponentProps<"div">, VariantProps<typeof tag_cva> {
   dot?: boolean;
-  variant: "default" | "primary" | "success" | "danger" | "warning";
-  size: "small" | "medium" | "large";
-  mode: "pill" | "default";
+  variant?: "default" | "primary" | "success" | "danger" | "warning";
+  size?: "small" | "medium" | "large";
+  mode?: "pill" | "default";
 }
 
-const Tag = forwardRef<HTMLDivElement, TagProps>(
-  (
-    { children, variant, size, mode, dot = false, className, ...props },
-    ref,
-  ) => {
-    return (
-      <div
-        ref={ref}
-        className={clx(tag_cva({ variant, size, mode }), className)}
-        {...props}
-      >
-        {dot && <span className={clx(dot_cva({ size }))} />}
-        {children}
-      </div>
-    );
-  },
-);
+const Tag: ForwardRefExoticComponent<TagProps & RefAttributes<HTMLDivElement>> =
+  forwardRef(
+    (
+      {
+        children,
+        variant = "default",
+        size = "medium",
+        mode = "default",
+        dot = false,
+        className,
+        ...props
+      },
+      ref,
+    ) => {
+      return (
+        <div
+          ref={ref}
+          className={clx(tag_cva({ variant, size, mode }), className)}
+          {...props}
+        >
+          {dot && <span className={clx(dot_cva({ size }))} />}
+          {children}
+        </div>
+      );
+    },
+  );
 
 Tag.displayName = "Tag";
 
 export { Tag };
-export type { TagProps };


### PR DESCRIPTION
1. Remove `size` and `mode` as required props for `AnnounceBarTag`
2. Use early return for `AnnounceBarTag` such that when `asChild` is true, the `variant`, `size` and `mode` props are not forwarded along into the child component