### PR TITLE
Fix/calendar interaction

### DIFF
--- a/.changeset/real-suits-rescue.md
+++ b/.changeset/real-suits-rescue.md
@@ -1,0 +1,5 @@
+---
+"@govtechmy/myds-react": patch
+---
+
+Refactor Calendar, DatePicker & DateRangePicker to update selected date on month/year change

--- a/packages/react/src/components/date-picker.tsx
+++ b/packages/react/src/components/date-picker.tsx
@@ -68,10 +68,9 @@ const DatePicker: FC<DatePickerProps> = ({
             {date ? formatDate(date) : placeholder}
           </Button>
         </DialogTrigger>
-        <DialogBody hideClose className="min-w-fit w-fit">
+        <DialogBody hideClose className="sm:w-fit">
           <DialogContent className="p-0">
             <Calendar
-              className="w-[304px]"
               disabled={disabled}
               locale={_locale}
               mode="single"

--- a/packages/react/src/components/daterange-picker.tsx
+++ b/packages/react/src/components/daterange-picker.tsx
@@ -82,7 +82,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
                 : placeholder}
             </Button>
           </DialogTrigger>
-          <DialogBody className="min-w-fit w-fit" hideClose>
+          <DialogBody className="w-fit min-w-fit" hideClose>
             <DialogContent className="w-[304px] p-0">
               <Calendar
                 disabled={
@@ -103,6 +103,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
                 }}
                 required
                 selected={selectedDateRange}
+                daterange="from"
                 {...props}
               />
             </DialogContent>
@@ -124,7 +125,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
                 : placeholder}
             </Button>
           </DialogTrigger>
-          <DialogBody className="min-w-fit w-fit" hideClose>
+          <DialogBody className="w-fit min-w-fit" hideClose>
             <DialogContent className="w-[304px] p-0">
               <Calendar
                 disabled={
@@ -142,6 +143,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
                 onSelect={setSelectedDateRange}
                 required
                 selected={selectedDateRange}
+                daterange="to"
                 {...props}
               />
             </DialogContent>
@@ -186,6 +188,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
               }}
               required
               selected={selectedDateRange}
+              daterange="from"
               {...props}
             />
           </PopoverContent>
@@ -223,6 +226,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
               onSelect={setSelectedDateRange}
               required
               selected={selectedDateRange}
+              daterange="to"
               {...props}
             />
           </PopoverContent>


### PR DESCRIPTION
Changes:
- set date on month & year select
  - to achieve that in `DateRangePicker`, a `daterange` prop is added to identify if calendar is `from` or `to` to know which end-range was changed
- make mobile dialog fit the screen width
- fix table html layout, adding `<tbody>` & `<tr>`