### PR TITLE
Fix/hover icon issue

### DIFF
--- a/.changeset/lemon-students-crash.md
+++ b/.changeset/lemon-students-crash.md
@@ -1,0 +1,5 @@
+---
+"@govtechmy/myds-docs": patch
+---
+
+UI:Hover Icon Fix

--- a/.changeset/lemon-students-crash.md
+++ b/.changeset/lemon-students-crash.md
@@ -2,4 +2,4 @@
 "@govtechmy/myds-docs": patch
 ---
 
-UI:Hover Icon Fix
+UI:Icon Docs - Fix: Hover did not display copy icon

--- a/apps/docs/components/icon/ResultMap.tsx
+++ b/apps/docs/components/icon/ResultMap.tsx
@@ -29,7 +29,7 @@ const IconGridItem: FunctionComponent<{ icon: IconData }> = ({ icon }) => {
         <div ref={iconRef} className="flex items-center justify-center">
           {icon.svg}
         </div>
-        <div className="absolute h-full w-full opacity-0 focus-within:opacity-100">
+        <div className="absolute h-full w-full opacity-0 focus-within:opacity-100 hover:opacity-100">
           <Button
             onClick={() => handleCopy()}
             className="text-txt-black-500 flex h-full w-full flex-row-reverse items-start rounded-lg border-0 bg-transparent p-4 hover:bg-gray-50/10 dark:text-[#303030]"


### PR DESCRIPTION
1. Small fix on the hover on icon documentation where it doesnt display copy icon on hover, only on focus or on click 