### PR TITLE
Chore/docs cleanup

### DIFF
--- a/apps/docs/content/docs/develop/(components)/accordion.mdx
+++ b/apps/docs/content/docs/develop/(components)/accordion.mdx
@@ -336,7 +336,6 @@ Setting `disabled` to `true` in `Accordion` will disable all the `AccordionItem`
     type: {
       type: "enum",
       typeDescription: "single | multiple",
-      default: "small",
     },
     value: {
       description:

--- a/apps/docs/content/docs/develop/(components)/accordion.ms.mdx
+++ b/apps/docs/content/docs/develop/(components)/accordion.ms.mdx
@@ -330,7 +330,6 @@ Menetapkan `disabled` kepada `true` dalam `Accordion` akan melumpuhkan semua kom
     type: {
       type: "enum",
       typeDescription: "single | multiple",
-      default: "small",
     },
     value: {
       description:

--- a/apps/docs/content/docs/develop/(components)/search-bar.mdx
+++ b/apps/docs/content/docs/develop/(components)/search-bar.mdx
@@ -599,4 +599,3 @@ type={{
 ### SearchBarResultsGroup
 
 `SearchBarResultsGroup` is abstracted from cmdk's `Command.Group`. Please refer to the API references in [this documentation](https://github.com/pacocoursey/cmdk#group-cmdk-group-hidden)
-```

--- a/apps/docs/content/docs/develop/(components)/search-bar.ms.mdx
+++ b/apps/docs/content/docs/develop/(components)/search-bar.ms.mdx
@@ -599,4 +599,3 @@ type={{
 ### SearchBarResultsGroup
 
 `SearchBarResultsGroup` disarikan daripada `Command.Group` cmdk. Sila rujuk rujukan API dalam [dokumentasi ini](https://github.com/pacocoursey/cmdk#group-cmdk-group-hidden)
-```

--- a/apps/docs/content/docs/develop/(components)/select.mdx
+++ b/apps/docs/content/docs/develop/(components)/select.mdx
@@ -605,8 +605,8 @@ You can customize the value display by using the `SelectValue` component. It all
     variant: {
       description: "Variant of the select value display",
       type: "enum",
-      typeDescription: "default | ghost",
-      default: "default",
+      typeDescription: "outline | ghost",
+      default: "outline",
     },
     defaultValue: {
       description: "Initial state of the select (uncontrolled)",

--- a/apps/docs/content/docs/develop/(components)/select.ms.mdx
+++ b/apps/docs/content/docs/develop/(components)/select.ms.mdx
@@ -605,8 +605,8 @@ Anda boleh menyesuaikan paparan nilai dengan menggunakan komponen `SelectValue`.
     variant: {
       description: "Varian paparan nilai pilihan",
       type: "enum",
-      typeDescription: "default | ghost",
-      default: "default",
+      typeDescription: "outline | ghost",
+      default: "outline",
     },
     defaultValue: {
       description: "Keadaan awal pilihan (tidak terkawal)",

--- a/apps/docs/content/docs/develop/(components)/toast.mdx
+++ b/apps/docs/content/docs/develop/(components)/toast.mdx
@@ -261,7 +261,3 @@ const { toast } = useToast();
 
 ### ToastClose
 `ToastClose` is abstracted from Radix UI's `ToastClose`. Please refer to the API references in this [documentation](https://www.radix-ui.com/primitives/docs/components/toast#close).
-
-
-
-```

--- a/apps/docs/content/docs/develop/(components)/toast.ms.mdx
+++ b/apps/docs/content/docs/develop/(components)/toast.ms.mdx
@@ -275,7 +275,3 @@ const { toast } = useToast();
 
 ### ToastClose
 `ToastClose` menggunakan `ToastClose` dari komponen perpustakaan Radiux UI. Sila rujuk kepada rujukan API dalam  [dokumentasi ini](https://www.radix-ui.com/primitives/docs/components/toast#close).
-
-
-
-```


### PR DESCRIPTION
Documentation Cleanup

1. Remove empty code blocks at end of page for `develop/search-bar` and `develop/toast`
2. Remove default value for `type` prop in `develop/accordion`
3. Replace `Select` variant from `default` to `outline` ([ref](https://github.com/govtechmy/myds/blob/1edaa4cd258060f0010f0b9acee503df36568b93/packages/react/src/components/select.tsx#L13)) 