### PR TITLE
fix: wrong default value type accordion

### DIFF
--- a/apps/docs/content/docs/develop/(components)/accordion.mdx
+++ b/apps/docs/content/docs/develop/(components)/accordion.mdx
@@ -189,7 +189,7 @@ Use the `type` prop to change how the content should be displayed!
 
 <Tabs items={["Preview", "Code"]} defaultValue="Preview">
   <Tab value="Preview" className="not-prose">
-    <Accordion type="multiple" defaultValue="item-1">
+    <Accordion type="multiple" defaultValue={["item-1"]}>
       {items.default}
     </Accordion>
   </Tab>


### PR DESCRIPTION
Passed an incorrect defaultValue when `type = "multiple"`