### PR TITLE
DOCS: include missing quicklinks

### DIFF
--- a/apps/docs/content/docs/develop/(components)/summarylist.mdx
+++ b/apps/docs/content/docs/develop/(components)/summarylist.mdx
@@ -114,6 +114,15 @@ import { SwapIcon } from "@govtechmy/myds-react/icon";
   </Tab>
 </Tabs>
 
+<Quicklinks
+  links={{
+    storybook:
+      "https://myds-storybook.vercel.app/?path=%2Fdocs%2Fgovtechmy-myds-react-summarylist--docs",
+    source:
+      "https://github.com/govtechmy/myds/blob/main/packages/react/src/components/summary-list.tsx",
+  }}
+/>
+
 ## Usage
 
 ```ts copy title="Import"

--- a/apps/docs/content/docs/develop/(components)/summarylist.ms.mdx
+++ b/apps/docs/content/docs/develop/(components)/summarylist.ms.mdx
@@ -114,6 +114,15 @@ import { SwapIcon } from "@govtechmy/myds-react/icon";
   </Tab>
 </Tabs>
 
+<Quicklinks
+  links={{
+    storybook:
+      "https://myds-storybook.vercel.app/?path=%2Fdocs%2Fgovtechmy-myds-react-summarylist--docs",
+    source:
+      "https://github.com/govtechmy/myds/blob/main/packages/react/src/components/summary-list.tsx",
+  }}
+/>
+
 ## Penggunaan
 
 ```ts copy title="Import"

--- a/apps/docs/content/docs/develop/(components)/tabs.mdx
+++ b/apps/docs/content/docs/develop/(components)/tabs.mdx
@@ -84,6 +84,15 @@ import { Tab, Tabs as FumaTabs } from "fumadocs-ui/components/tabs";
    </Tab>
 </FumaTabs>
 
+<Quicklinks
+  links={{
+    storybook:
+      "https://myds-storybook.vercel.app/?path=%2Fdocs%2Fgovtechmy-myds-react-tabs--docs",
+    source:
+      "https://github.com/govtechmy/myds/blob/main/packages/react/src/components/tabs.tsx",
+  }}
+/>
+
 ## Usage
 
 ```ts copy title="Import"

--- a/apps/docs/content/docs/develop/(components)/tabs.ms.mdx
+++ b/apps/docs/content/docs/develop/(components)/tabs.ms.mdx
@@ -79,6 +79,15 @@ import { Tab, Tabs as FumaTabs } from "fumadocs-ui/components/tabs";
 
 </FumaTabs>
 
+<Quicklinks
+  links={{
+    storybook:
+      "https://myds-storybook.vercel.app/?path=%2Fdocs%2Fgovtechmy-myds-react-tabs--docs",
+    source:
+      "https://github.com/govtechmy/myds/blob/main/packages/react/src/components/tabs.tsx",
+  }}
+/>
+
 ## Penggunaan
 
 ```ts copy title="Import"


### PR DESCRIPTION
The documentation of `SummaryList` and `Tabs` component did not include their respective `Source` and `Storybook` quicklinks.