### PR TITLE
Fix/navbar mobile

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -43,10 +43,10 @@
 
   /** Need to do this because fumadocs preset is overriding custom breakpoints. For: navbar, footer */
   .max-w-container {
-    @apply !max-w-screen-xl xl:!px-0;
+    @apply !max-w-screen-xl !px-4.5 md:!px-6;
   }
   .container {
-    @apply !max-w-screen-xl xl:!px-0;
+    @apply !max-w-screen-xl !px-4.5 md:!px-6;
   }
 
   td {

--- a/apps/docs/components/Footer.tsx
+++ b/apps/docs/components/Footer.tsx
@@ -16,13 +16,7 @@ type Props = {
 };
 
 export default function Footer(props: Props) {
-  // const format = useFormatter();
-  // const t = useTranslations();
   const { t } = useContext(RosettaContext);
-
-  const className = {
-    link: "text-sm text-black-700 [text-underline-position:from-font] hover:text-black-900 hover:underline",
-  };
 
   return (
     <div className="bg-bg-gray-50 border-otl-gray-200 border-t py-8 lg:py-16">
@@ -36,18 +30,13 @@ export default function Footer(props: Props) {
                 height={28}
                 alt="Jata Negara"
               />
-              <div>
-                <span className="whitespace-nowrap font-semibold text-inherit">
-                  {props.ministry}
-                </span>
-              </div>
+              <span className="whitespace-nowrap font-semibold text-inherit">
+                {props.ministry}
+              </span>
             </div>
-            <p
-              className="text-black-700 text-sm"
-              dangerouslySetInnerHTML={{
-                __html: props.descriptionWithNewlines.replaceAll("\n", "<br/>"),
-              }}
-            ></p>
+            <p className="text-black-700 whitespace-pre-line text-sm">
+              {props.descriptionWithNewlines}
+            </p>
           </div>
           <div className="flex flex-col gap-6 text-sm lg:flex-row">
             {props.links.map((item, index) => (
@@ -57,7 +46,7 @@ export default function Footer(props: Props) {
                   {item.links.map(({ name, href }) => (
                     <a
                       key={name}
-                      className={className.link}
+                      className="text-black-700 hover:text-black-900 text-sm [text-underline-position:from-font] hover:underline"
                       target="_blank"
                       rel="noopenner noreferrer"
                       href={href}

--- a/apps/storybook/stories/navbar.stories.tsx
+++ b/apps/storybook/stories/navbar.stories.tsx
@@ -214,7 +214,7 @@ export const NavbarCustomKementerianDigital = createStory(
           Ministry Of Digital
         </NavbarLogo>
         <NavbarMenu>
-          <NavbarMenuItem href="/menu1">MinistryProfile</NavbarMenuItem>
+          <NavbarMenuItem href="/menu1">Ministry Profile</NavbarMenuItem>
           <NavbarMenuItem href="/menu2">Policy</NavbarMenuItem>
           <NavbarMenuItem href="/menu3">Achievements</NavbarMenuItem>
           <NavbarMenuItem href="/menu4">Media</NavbarMenuItem>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -253,6 +253,7 @@
     "input-otp": "^1.4.1",
     "mitt": "^3.0.1",
     "react-day-picker": "^9.5.1",
+    "react-remove-scroll": "^2.7.1",
     "tailwind-merge": "^2.4.0"
   }
 }

--- a/packages/react/src/components/breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb.tsx
@@ -6,13 +6,13 @@ import { ChevronRightIcon } from "../icons/chevron-right";
 
 const breadcrumb_cva = cva(
   [
-    "group flex flex-wrap select-none items-center font-body font-medium text-body-sm py-1 px-3 rounded-md gap-1",
+    "group flex flex-wrap select-none items-center font-body font-medium text-body-sm rounded-md gap-1",
   ],
   {
     variants: {
       variant: {
         default: "",
-        fill: "bg-bg-washed",
+        fill: "py-1 px-3 bg-bg-washed",
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/masthead.tsx
+++ b/packages/react/src/components/masthead.tsx
@@ -69,7 +69,7 @@ const MastheadHeader: FunctionComponent<ComponentProps<"div">> = ({
 }) => {
   return (
     <div
-      className="px-4.5 flex items-center gap-2 overflow-x-hidden py-2 outline-none sm:py-1 xl:px-0"
+      className="px-4.5 flex items-center gap-2 overflow-x-hidden py-2 outline-none sm:py-1 md:px-6"
       {...props}
     >
       <MalaysiaFlagIcon className="inline-block aspect-auto w-fit shrink-0" />
@@ -138,7 +138,7 @@ const MastheadContent: FunctionComponent<
       )}
       {...props}
     >
-      <div className="px-4.5 gap-4.5 flex flex-col pb-6 pt-3 sm:grid-cols-2 sm:flex-row sm:px-6 sm:pb-8 sm:pt-6 xl:px-0">
+      <div className="px-4.5 gap-4.5 flex flex-col pb-6 pt-3 sm:grid-cols-2 sm:flex-row sm:px-6 sm:pb-8 sm:pt-6">
         {children}
       </div>
     </CollapsibleContent>

--- a/packages/react/src/components/masthead.tsx
+++ b/packages/react/src/components/masthead.tsx
@@ -138,7 +138,7 @@ const MastheadContent: FunctionComponent<
       )}
       {...props}
     >
-      <div className="px-4.5 gap-4.5 flex flex-col pb-6 pt-3 sm:grid-cols-2 sm:flex-row sm:px-6 sm:pb-8 sm:pt-6">
+      <div className="px-4.5 gap-4.5 flex flex-col pb-6 pt-3 sm:grid-cols-2 sm:flex-row sm:pb-8 sm:pt-6 md:px-6">
         {children}
       </div>
     </CollapsibleContent>

--- a/packages/react/src/components/navbar.tsx
+++ b/packages/react/src/components/navbar.tsx
@@ -62,7 +62,7 @@ const Navbar: FunctionComponent<NavbarProps> = ({
         data-nosnippet
         {...props}
       >
-        <div className="relative mx-auto flex h-16 max-w-screen-xl items-center justify-between gap-4 px-4.5 lg:px-6 max-md:h-14">
+        <div className="relative mx-auto flex h-16 max-w-screen-xl items-center justify-between gap-4 px-4.5 md:px-6 max-md:h-14">
           {children}
         </div>
       </header>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       react-day-picker:
         specifier: ^9.5.1
         version: 9.5.1(react@18.3.1)
+      react-remove-scroll:
+        specifier: ^2.7.1
+        version: 2.7.1(@types/react@18.3.12)(react@18.3.1)
       tailwind-merge:
         specifier: ^2.4.0
         version: 2.5.4
@@ -6126,6 +6129,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-remove-scroll@2.6.0:
     resolution: {integrity: sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==}
     engines: {node: '>=10'}
@@ -6136,12 +6149,32 @@ packages:
       '@types/react':
         optional: true
 
+  react-remove-scroll@2.7.1:
+    resolution: {integrity: sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7048,12 +7081,32 @@ packages:
       '@types/react':
         optional: true
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sidecar@1.1.2:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -14252,6 +14305,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.12)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
   react-remove-scroll@2.6.0(@types/react@18.3.12)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -14263,10 +14324,29 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
+  react-remove-scroll@2.7.1(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.12)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.12)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.12)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.12)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+
   react-style-singleton@2.2.1(@types/react@18.3.12)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  react-style-singleton@2.2.3(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
@@ -15452,7 +15532,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
+  use-callback-ref@1.3.3(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
   use-sidecar@1.1.2(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  use-sidecar@1.1.3(@types/react@18.3.12)(react@18.3.1):
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1


### PR DESCRIPTION
# Changes

## Navbar
Refactor positioning of menu in mobile

> -mb-16 translate-y-full

current menu is positioned absolutely with 64px margin from top
adding `Masthead` above the navbar will then break the positioning

### proposed fix
refactor mobile navbar menu to use `Popover` component
use `PopoverAnchor` to anchor menu to the navbar with the ID generated by `useId()`
add `react-remove-scroll` to disable scroll when menu is open

## Breadcrumb
omit padding from base style, add to `fill` variant only

## Misc
standardise `Masthead`, `Navbar` and `container` padding to `px-4.5 md:px-6`
