### PR TITLE
hotfix: pagination key ... duplicate, change key

### DIFF
--- a/.changeset/rich-buttons-destroy.md
+++ b/.changeset/rich-buttons-destroy.md
@@ -1,0 +1,5 @@
+---
+"@govtechmy/myds-react": patch
+---
+
+fix pagination : error duplicate key (...) thrown by myds auto pagination due to design --> pageiniital (...) pagemiddle (...) pagefinal

--- a/packages/react/src/components/pagination.tsx
+++ b/packages/react/src/components/pagination.tsx
@@ -290,8 +290,8 @@ const AutoPagination: ForwardRefExoticComponent<AutoPaginationProps> =
             <PaginationItem>
               {previous || <PaginationPrevious />}
             </PaginationItem>
-            {visiblePages.map((page) => (
-              <PaginationItem key={page}>
+            {visiblePages.map((page, index) => (
+              <PaginationItem key={index}>
                 {page === "..." ? (
                   <PaginationEllipsis />
                 ) : (


### PR DESCRIPTION
Main Description

hotfix : fix pagination key where  pages is set to key and some design use  initialPage ... middlePage ... endPage
where ... causes react to throw error due to ... duplication.


Type of change
[✅ ] fix feature
Affected endpoints
Backend
Checklist
[] My code follows the style guidelines of this project
[✅] I have performed a self-review of my code
[✅] I have commented my code, particularly in hard-to-understand areas
I have made corresponding changes to the documentation
[✅] My changes generate no new warnings
I have added tests that prove my fix is effective or that my feature works