### PR TITLE
fix windows build by making fumadocs-docgen as optional dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,19 @@ If you open a pull request for a new feature, we're likely to close it not becau
 
 MYDS is largely managed by [Turborepo](https://turbo.build/). If you would like contribute via code, we recommend learning to utilise the features of Turborepo to make your life easier, from running multiple dev servers, scope installs, using codegens and many more.
 
+## Building on Windows
+
+The documentation site (`apps/docs`) uses `fumadocs-docgen` as an optional dependency. This package may fail to install on Windows due to Playwright dependencies. If you encounter build errors related to Playwright when building the docs:
+
+1. The build will continue without the `fumadocs-docgen` features (install instructions enhancement)
+2. Alternatively, you can skip installing optional dependencies with:
+   ```sh
+   pnpm install --no-optional
+   ```
+3. The documentation site will build successfully without this package
+
+This is expected behavior and does not affect the functionality of the documentation.
+
 ## Coding standards
 
 Our code formatting rules are defined in the [prettierc](./.prettierrc) and [\_eslint](./packages/_eslint/).

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,1 +1,24 @@
-# docs
+# MYDS Documentation Site
+
+This is the documentation site for the Malaysian Government Design System (MYDS).
+
+## Development
+
+```bash
+pnpm dev
+```
+
+## Building
+
+```bash
+pnpm build
+```
+
+## Windows Build Support
+
+The project uses `fumadocs-docgen` as an optional dependency to avoid Playwright-related build failures on Windows. The `remarkInstall` plugin from `fumadocs-docgen` is conditionally loaded in `source.config.ts`:
+
+- If the package is available (macOS/Linux), it will be used to enhance the documentation with install instructions
+- If the package is not available or fails to load (Windows), the build will continue without this feature
+
+This ensures that the documentation can be built successfully on all platforms.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "start": "next start",
+    "start": "next start --port 4000",
     "postinstall": "fumadocs-mdx",
     "lint": "next lint",
     "lint-staged": "next lint --fix"
@@ -16,7 +16,6 @@
     "@govtechmy/myds-style": "workspace:*",
     "@hookform/resolvers": "^5.2.0",
     "fumadocs-core": "14.2.1",
-    "fumadocs-docgen": "^1.3.7",
     "fumadocs-mdx": "11.1.1",
     "fumadocs-ui": "13.4.10",
     "next": "^14.2.17",
@@ -25,6 +24,9 @@
     "react-hook-form": "^7.61.1",
     "rosetta": "^1.1.0",
     "zod": "^4.0.10"
+  },
+  "optionalDependencies": {
+    "fumadocs-docgen": "^1.3.7"
   },
   "devDependencies": {
     "@types/mdx": "^2.0.13",

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,20 +1,30 @@
 import { remarkImage } from "fumadocs-core/mdx-plugins";
-import { remarkInstall } from "fumadocs-docgen";
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
 
 export const { docs, meta } = defineDocs();
 
+// Conditionally import fumadocs-docgen to avoid Playwright issues on Windows
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let remarkInstall: any = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  remarkInstall = require("fumadocs-docgen").remarkInstall;
+} catch {
+  // fumadocs-docgen not available (optional dependency)
+  // This is expected on Windows or when the package is not installed
+}
+
+const remarkPlugins = [
+  ...(remarkInstall ? [remarkInstall] : []),
+  [
+    remarkImage,
+    {
+      publicDir: "https://d2391uizq0pg2.cloudfront.net",
+      useImport: false,
+    },
+  ],
+];
+
 export default defineConfig({
-  mdxOptions: {
-    remarkPlugins: [
-      remarkInstall,
-      [
-        remarkImage,
-        {
-          publicDir: "https://d2391uizq0pg2.cloudfront.net",
-          useImport: false,
-        },
-      ],
-    ],
-  },
+  mdxOptions: { remarkPlugins },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       fumadocs-core:
         specifier: 14.2.1
         version: 14.2.1(@types/react@18.3.12)(next@14.2.18(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      fumadocs-docgen:
-        specifier: ^1.3.7
-        version: 1.3.7(typescript@5.6.3)
       fumadocs-mdx:
         specifier: 11.1.1
         version: 11.1.1(acorn@8.14.0)(fumadocs-core@14.2.1(@types/react@18.3.12)(next@14.2.18(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@14.2.18(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -77,6 +74,10 @@ importers:
       zod:
         specifier: ^4.0.10
         version: 4.0.10
+    optionalDependencies:
+      fumadocs-docgen:
+        specifier: ^1.3.7
+        version: 1.3.7(typescript@5.6.3)
     devDependencies:
       '@types/mdx':
         specifier: ^2.0.13
@@ -9744,6 +9745,7 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
+    optional: true
 
   '@shikijs/engine-javascript@1.23.1':
     dependencies:
@@ -9756,6 +9758,7 @@ snapshots:
       '@shikijs/types': 2.5.0
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 3.1.1
+    optional: true
 
   '@shikijs/engine-oniguruma@1.23.1':
     dependencies:
@@ -9766,10 +9769,12 @@ snapshots:
     dependencies:
       '@shikijs/types': 2.5.0
       '@shikijs/vscode-textmate': 10.0.2
+    optional: true
 
   '@shikijs/langs@2.5.0':
     dependencies:
       '@shikijs/types': 2.5.0
+    optional: true
 
   '@shikijs/rehype@1.23.1':
     dependencies:
@@ -9783,6 +9788,7 @@ snapshots:
   '@shikijs/themes@2.5.0':
     dependencies:
       '@shikijs/types': 2.5.0
+    optional: true
 
   '@shikijs/transformers@1.23.1':
     dependencies:
@@ -9797,8 +9803,10 @@ snapshots:
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+    optional: true
 
-  '@shikijs/vscode-textmate@10.0.2': {}
+  '@shikijs/vscode-textmate@10.0.2':
+    optional: true
 
   '@shikijs/vscode-textmate@9.3.0': {}
 
@@ -10522,6 +10530,7 @@ snapshots:
       fast-glob: 3.3.3
       minimatch: 9.0.5
       path-browserify: 1.0.1
+    optional: true
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -11581,7 +11590,8 @@ snapshots:
 
   co@4.6.0: {}
 
-  code-block-writer@13.0.3: {}
+  code-block-writer@13.0.3:
+    optional: true
 
   collapse-white-space@2.1.0: {}
 
@@ -12448,6 +12458,7 @@ snapshots:
   estree-util-value-to-estree@3.3.2:
     dependencies:
       '@types/estree': 1.0.6
+    optional: true
 
   estree-util-visit@2.0.0:
     dependencies:
@@ -12543,6 +12554,7 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+    optional: true
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -12744,6 +12756,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    optional: true
 
   fumadocs-mdx@11.1.1(acorn@8.14.0)(fumadocs-core@14.2.1(@types/react@18.3.12)(next@14.2.18(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@14.2.18(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -12774,6 +12787,7 @@ snapshots:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   fumadocs-ui@13.4.10(@types/react-dom@18.3.1)(@types/react@18.3.12)(next@14.2.18(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.15(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.6.3))):
     dependencies:
@@ -13056,6 +13070,7 @@ snapshots:
       zwitch: 2.0.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   hast-util-to-html@9.0.3:
     dependencies:
@@ -13084,6 +13099,7 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+    optional: true
 
   hast-util-to-jsx-runtime@2.3.2:
     dependencies:
@@ -14718,7 +14734,8 @@ snapshots:
 
   npm-to-yarn@3.0.0: {}
 
-  npm-to-yarn@3.0.1: {}
+  npm-to-yarn@3.0.1:
+    optional: true
 
   nyc@15.1.0:
     dependencies:
@@ -14821,6 +14838,7 @@ snapshots:
       emoji-regex-xs: 1.0.0
       regex: 6.0.1
       regex-recursion: 6.0.2
+    optional: true
 
   open@8.4.2:
     dependencies:
@@ -14876,6 +14894,7 @@ snapshots:
       '@oxc-transform/binding-linux-x64-musl': 0.48.2
       '@oxc-transform/binding-win32-arm64-msvc': 0.48.2
       '@oxc-transform/binding-win32-x64-msvc': 0.48.2
+    optional: true
 
   p-filter@2.1.0:
     dependencies:
@@ -14975,7 +14994,8 @@ snapshots:
       camel-case: 3.0.0
       upper-case-first: 1.1.2
 
-  path-browserify@1.0.1: {}
+  path-browserify@1.0.1:
+    optional: true
 
   path-case@2.1.1:
     dependencies:
@@ -15168,7 +15188,8 @@ snapshots:
 
   property-information@6.5.0: {}
 
-  property-information@7.0.0: {}
+  property-information@7.0.0:
+    optional: true
 
   proxy-agent@6.4.0:
     dependencies:
@@ -15415,6 +15436,7 @@ snapshots:
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
+    optional: true
 
   regex-utilities@2.3.0: {}
 
@@ -15423,6 +15445,7 @@ snapshots:
   regex@6.0.1:
     dependencies:
       regex-utilities: 2.3.0
+    optional: true
 
   regexp-tree@0.1.27: {}
 
@@ -15723,6 +15746,7 @@ snapshots:
       '@shikijs/types': 2.5.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+    optional: true
 
   side-channel@1.0.6:
     dependencies:
@@ -16211,6 +16235,7 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.26.1
       code-block-writer: 13.0.3
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.5))(@types/node@22.9.0)(typescript@5.6.3):
     dependencies:


### PR DESCRIPTION
adding Window support build by making `fumadocs-docgen` as an optional dependency to avoid Playwright-related build failures on Windows.