### PR TITLE
Feature/SSD-825-move-transistory-assistance

### DIFF
--- a/apps/docs/content/docs/develop/meta.en.json
+++ b/apps/docs/content/docs/develop/meta.en.json
@@ -15,25 +15,6 @@
     "(installation)/vite",
     "(installation)/laravel",
 
-   "---Transistory Assistance (CSS)---",
-  "(transistory-assistance)/ta-accordion/",
-  "(transistory-assistance)/ta-alert/",
-  "(transistory-assistance)/ta-button/",
-  "(transistory-assistance)/ta-callout/",
-  "(transistory-assistance)/ta-card/",
-  "(transistory-assistance)/ta-dialog/",
-  "(transistory-assistance)/ta-input/",
-  "(transistory-assistance)/ta-label/",
-  "(transistory-assistance)/ta-link/",
-  "(transistory-assistance)/ta-pagination/",
-  "(transistory-assistance)/ta-popover/",
-  "(transistory-assistance)/ta-select/",
-  "(transistory-assistance)/ta-spinner/",
-  "(transistory-assistance)/ta-tag/",
-  "(transistory-assistance)/ta-theme-switcher/",
-  "(transistory-assistance)/ta-toggle/",
-
-
     "---Template ---",
     "(template)/login",
     "(template)/registration",
@@ -82,11 +63,29 @@
     "(components)/toast",
     "(components)/toggle",
     "(components)/tooltip",
-    
+
     "---Hooks ---",
     "(hooks)/use-pagination",
     "(hooks)/use-theme",
-    "(hooks)/use-toast"
+    "(hooks)/use-toast",
+
+    "---Transistory Assistance (CSS)---",
+    "(transistory-assistance)/ta-accordion/",
+    "(transistory-assistance)/ta-alert/",
+    "(transistory-assistance)/ta-button/",
+    "(transistory-assistance)/ta-callout/",
+    "(transistory-assistance)/ta-card/",
+    "(transistory-assistance)/ta-dialog/",
+    "(transistory-assistance)/ta-input/",
+    "(transistory-assistance)/ta-label/",
+    "(transistory-assistance)/ta-link/",
+    "(transistory-assistance)/ta-pagination/",
+    "(transistory-assistance)/ta-popover/",
+    "(transistory-assistance)/ta-select/",
+    "(transistory-assistance)/ta-spinner/",
+    "(transistory-assistance)/ta-tag/",
+    "(transistory-assistance)/ta-theme-switcher/",
+    "(transistory-assistance)/ta-toggle/"
   ],
   "root": true
 }

--- a/apps/docs/content/docs/develop/meta.ms.json
+++ b/apps/docs/content/docs/develop/meta.ms.json
@@ -15,24 +15,6 @@
     "(installation)/vite",
     "(installation)/laravel",
 
-    "---Komponen Peralihan (CSS)---",
-    "(transistory-assistance)/ta-accordion/",
-    "(transistory-assistance)/ta-alert/",
-    "(transistory-assistance)/ta-button/",
-    "(transistory-assistance)/ta-callout/",
-    "(transistory-assistance)/ta-card/",
-    "(transistory-assistance)/ta-dialog/",
-    "(transistory-assistance)/ta-input/",
-    "(transistory-assistance)/ta-label/",
-    "(transistory-assistance)/ta-link/",
-    "(transistory-assistance)/ta-pagination/",
-    "(transistory-assistance)/ta-popover/",
-    "(transistory-assistance)/ta-select/",
-    "(transistory-assistance)/ta-spinner/",
-    "(transistory-assistance)/ta-tag/",
-    "(transistory-assistance)/ta-theme-switcher/",
-    "(transistory-assistance)/ta-toggle/",
-
     "---Template ---",
     "(template)/login",
     "(template)/registration",
@@ -81,11 +63,29 @@
     "(components)/toast",
     "(components)/toggle",
     "(components)/tooltip",
-    
+
     "---Hooks ---",
     "(hooks)/use-pagination",
     "(hooks)/use-theme",
-    "(hooks)/use-toast"
+    "(hooks)/use-toast",
+
+    "---Komponen Peralihan (CSS)---",
+    "(transistory-assistance)/ta-accordion/",
+    "(transistory-assistance)/ta-alert/",
+    "(transistory-assistance)/ta-button/",
+    "(transistory-assistance)/ta-callout/",
+    "(transistory-assistance)/ta-card/",
+    "(transistory-assistance)/ta-dialog/",
+    "(transistory-assistance)/ta-input/",
+    "(transistory-assistance)/ta-label/",
+    "(transistory-assistance)/ta-link/",
+    "(transistory-assistance)/ta-pagination/",
+    "(transistory-assistance)/ta-popover/",
+    "(transistory-assistance)/ta-select/",
+    "(transistory-assistance)/ta-spinner/",
+    "(transistory-assistance)/ta-tag/",
+    "(transistory-assistance)/ta-theme-switcher/",
+    "(transistory-assistance)/ta-toggle/"
   ],
   "root": true
 }


### PR DESCRIPTION
## Summarise the feature

Issue ticket: SS-825

Description: 
- Move transistory assistance to the bottom

<img width="1912" height="1035" alt="image" src="https://github.com/user-attachments/assets/3654aaa1-28c7-4afd-a3d2-dc71e4e375a8" />

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Affected endpoints

none

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
